### PR TITLE
53 design improvements

### DIFF
--- a/src/js/components/app-navigation.js
+++ b/src/js/components/app-navigation.js
@@ -2,6 +2,8 @@ import htmlUtilities from "../helper/html-utilities/index.js";
 import { handleFocusTrap } from "../helper/handle-focus-trap.js";
 import { mobileMenuToggle } from "../helper/mobile-menu-toggle.js";
 import { navigation } from "../const/navigation.js";
+import { mdQuery } from "../const/queries.js";
+import { stringToBoolean } from "../helper/string-to-boolean.js";
 import Storage from "../helper/storage/index.js";
 import Modal from "../helper/modal/index.js";
 
@@ -27,6 +29,17 @@ class AppNavigation extends HTMLElement {
     });
 
     navClose.addEventListener("click", this.closeNav);
+
+    mdQuery.addEventListener("change", (e) => {
+      if (
+        mdQuery.matches &&
+        stringToBoolean(
+          this.querySelector("nav").getAttribute("data-mobile-visible"),
+        )
+      ) {
+        this.closeNav();
+      }
+    });
   }
 
   userLogout() {
@@ -40,8 +53,11 @@ class AppNavigation extends HTMLElement {
    * @param {MouseEvent} e - Event from click.
    */
   closeNav(e) {
+    const navButton = document.querySelector("#nav-button");
     document.removeEventListener("keydown", this.handleFocusNav);
-    mobileMenuToggle(document.querySelector("#nav-button"));
+    mobileMenuToggle(navButton);
+    navButton.focus();
+    document.body.classList.remove("overflow-hidden");
   }
 
   /**
@@ -162,8 +178,6 @@ class AppNavigation extends HTMLElement {
       this.currentPage === href &&
       (href !== "/profile/" || isPersonalProfile)
     ) {
-      console.log(name);
-
       navItem.setAttribute("aria-current", "page");
       navItem.classList.add("font-medium");
       navItem.classList.remove("font-light");

--- a/src/js/components/app-navigation.js
+++ b/src/js/components/app-navigation.js
@@ -22,6 +22,7 @@ class AppNavigation extends HTMLElement {
     this.render();
     const navClose = document.querySelector("#nav-close");
     const navButton = document.querySelector("#nav-button");
+    const nav = this.querySelector("nav");
 
     navButton.addEventListener("click", (e) => {
       mobileMenuToggle(navButton);
@@ -33,11 +34,19 @@ class AppNavigation extends HTMLElement {
     mdQuery.addEventListener("change", (e) => {
       if (
         mdQuery.matches &&
-        stringToBoolean(
-          this.querySelector("nav").getAttribute("data-mobile-visible"),
-        )
+        stringToBoolean(nav.getAttribute("data-mobile-visible"))
       ) {
         this.closeNav();
+      }
+    });
+
+    document.addEventListener("click", (e) => {
+      if (
+        nav.getAttribute("data-mobile-visible") === "true" &&
+        e.target.closest("nav") !== nav &&
+        e.target.closest("button") !== navButton
+      ) {
+        this.closeNav(e);
       }
     });
   }

--- a/src/js/components/app-sidebar.js
+++ b/src/js/components/app-sidebar.js
@@ -41,6 +41,16 @@ class AppSidebar extends HTMLElement {
         this.closeSidebar();
       }
     });
+
+    document.addEventListener("click", (e) => {
+      if (
+        this.getAttribute("data-mobile-visible") === "true" &&
+        e.target.closest("app-sidebar") !== this &&
+        e.target.closest("button") !== sidebarButton
+      ) {
+        this.closeSidebar(e);
+      }
+    });
   }
 
   /**

--- a/src/js/components/app-sidebar.js
+++ b/src/js/components/app-sidebar.js
@@ -6,6 +6,8 @@ import { UserBadge } from "./user-badge.js";
 import { SearchBar } from "./search-bar.js";
 import { getPopularTags } from "../helper/get-popular-tags.js";
 import { renderUserSuggestions } from "../helper/render-user-suggestions.js";
+import { lgQuery } from "../const/queries.js";
+import { stringToBoolean } from "../helper/string-to-boolean.js";
 
 const sidebarButton = document.querySelector("#sidebar-button");
 
@@ -30,6 +32,15 @@ class AppSidebar extends HTMLElement {
     });
 
     sidebarClose.addEventListener("click", this.closeSidebar);
+
+    lgQuery.addEventListener("change", (e) => {
+      if (
+        lgQuery.matches &&
+        stringToBoolean(this.getAttribute("data-mobile-visible"))
+      ) {
+        this.closeSidebar();
+      }
+    });
   }
 
   /**
@@ -66,7 +77,9 @@ class AppSidebar extends HTMLElement {
    */
   closeSidebar(e) {
     mobileMenuToggle(sidebarButton);
+    sidebarButton.focus();
     document.removeEventListener("keydown", this.handleFocusSidebar);
+    document.body.classList.remove("overflow-hidden");
   }
 
   /**

--- a/src/js/components/post/post-dropdown.js
+++ b/src/js/components/post/post-dropdown.js
@@ -89,7 +89,10 @@ export class PostDropdown extends HTMLElement {
   closeDropdown = () => {
     this.removeEventListener("keydown", this.setDropdownFocus);
     window.removeEventListener("click", this.handleClickOutsideDropdown);
-
+    const dropdownButton = this.querySelector(
+      `#dropdown-${this.postId}_button`,
+    );
+    dropdownButton.focus();
     this.updateDropdownState(false);
   };
 

--- a/src/js/const/queries.js
+++ b/src/js/const/queries.js
@@ -1,0 +1,2 @@
+export const lgQuery = window.matchMedia("(min-width: 1024px)");
+export const mdQuery = window.matchMedia("(min-width: 768px)");

--- a/src/js/helper/handle-focus-trap.js
+++ b/src/js/helper/handle-focus-trap.js
@@ -1,5 +1,5 @@
 /**
- * Traps focus within a specified container until keys other than Shift, Tab, or Enter are pressed.
+ * Traps focus within a specified container until keys other than Shift, Tab, or Enter are pressed. Also sets focus to the first element when added as event handler.
  *
  * @param {HTMLElement} focusContainer - The HTML element containing focusable elements.
  * @param {String} focusableElements - A CSS selector for the focusable elements within the container.
@@ -31,10 +31,24 @@ export const handleFocusTrap = (
   if (focusContainer) {
     let firstFocusElement;
     let lastFocusElement;
+    let focusElements;
+    let isFocusableElement = false;
+
     if ((focusContainer, focusableElements)) {
-      const focusElements = focusContainer.querySelectorAll(focusableElements);
+      focusElements = focusContainer.querySelectorAll(focusableElements);
       firstFocusElement = focusElements[0];
       lastFocusElement = focusElements[focusElements.length - 1];
+    }
+
+    for (const element of focusElements) {
+      if (document.activeElement === element) {
+        isFocusableElement = true;
+        break;
+      }
+    }
+
+    if (!isFocusableElement) {
+      firstFocusElement.focus();
     }
 
     const isTabPressed = e.key === "Tab";

--- a/src/js/helper/mobile-menu-toggle.js
+++ b/src/js/helper/mobile-menu-toggle.js
@@ -10,6 +10,13 @@ export const mobileMenuToggle = (button) => {
   let isVisible = stringToBoolean(menu.getAttribute("data-mobile-visible"));
 
   isVisible = !isVisible;
+
+  if (isVisible) {
+    document.body.classList.add("overflow-hidden");
+  } else {
+    document.body.classList.remove("overflow-hidden");
+  }
+
   button.setAttribute("aria-expanded", isVisible);
   menu.setAttribute("data-mobile-visible", isVisible);
 };

--- a/src/js/helper/set-navigation-scroll.js
+++ b/src/js/helper/set-navigation-scroll.js
@@ -1,5 +1,6 @@
+import { mdQuery } from "../const/queries.js";
+
 const navigation = document.querySelector("app-navigation");
-const mdQuery = window.matchMedia("(min-width: 768px)");
 let previousScrollTop = 0;
 
 const navigationScrollHandler = (e) => {

--- a/src/js/helper/set-sidebar-scroll.js
+++ b/src/js/helper/set-sidebar-scroll.js
@@ -1,5 +1,5 @@
+import { lgQuery } from "../const/queries.js";
 const sidebar = document.querySelector("app-sidebar");
-const lgQuery = window.matchMedia("(min-width: 1024px)");
 let previousScrollTop = 0;
 
 const sidebarScrollHandler = (e) => {


### PR DESCRIPTION
This closes #67 

Focus trapping now sets the focus to be the first element when applied. Focus are also being properly set back to the buttons that opened the menus in the first place when closed.

Site cant be scrolled if menus are open and you can close the menus by clicking outside of them